### PR TITLE
Removed unused patch and added new one for gin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -109,8 +109,8 @@
       "drupal/password_policy": {
         "Policies should declare a config dependency on the plugin modules": "https://www.drupal.org/files/issues/2020-04-14/2918974-7-11.patch"
       },
-      "drupal/gin_login": {
-        "Add missing schema for gin_login": "https://www.drupal.org/files/issues/2021-01-13/gin_login-config_schema-3192526-8.patch"
+      "drupal/gin": {
+        "Missing config schema": "https://www.drupal.org/files/issues/2022-05-09/missing_config_schema_3279472.patch"
       }
     }
   }


### PR DESCRIPTION
#7 

The following patch has been merged into main repo, so it is now useless : https://www.drupal.org/project/gin_login/issues/3192526

Removed it and added another one from https://www.drupal.org/project/gin/issues/3279472