### PR TITLE
Reroll of failing patches

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,7 @@
         "POST /quickedit/metadata returning HTTP 503": "https://www.drupal.org/files/issues/2021-06-07/2893407-47.patch",
         "Callers of LayoutEntityHelperTrait::getEntitySections() do not account for the view mode": "https://www.drupal.org/files/issues/2021-12-09/3008924-rerolled-24.patch",
         "Claro + layout builder messages display additional icon in top left corner": "https://www.drupal.org/files/issues/2020-05-28/claro_layout_builder_extra_icon-3143237-4.patch",
-        "Expose Layout Builder data to REST and JSON:API": "https://www.drupal.org/files/issues/2022-01-27/2942975-core-3-x_180.patch",
+        "Expose Layout Builder data to REST and JSON:API": "https://www.drupal.org/files/issues/2022-05-03/2942975-core-3-x_190.patch",
         "Taxonomy pages crash with layout_builder enabled": "https://www.drupal.org/files/issues/2018-09-19/2959132-taxo-17-PASS.patch",
         "Add multilingual support for caching basefield definitions": "https://www.drupal.org/files/issues/2022-02-27/3114824-9.patch"
       },

--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
       "drupal/core": {
         "Translated field denormalization creates duplicate values": "https://www.drupal.org/files/issues/2019-07-02/2904423-core_8_8-72.patch",
         "Fix multilingual site's layout edit context issue": "https://www.drupal.org/files/issues/2019-12-19/3101231-19.patch",
-        "SQLite database locking errors cause fatal errors": "https://www.drupal.org/files/issues/1120020-59.patch",
+        "SQLite database locking errors cause fatal errors": "https://www.drupal.org/files/issues/2022-06-28/1120020-103.patch",
         "Error: Call to a member function getLabel() after enabling layout_builder": "https://www.drupal.org/files/issues/2019-11-14/2985882-entityfield-43.patch",
         "POST /quickedit/metadata returning HTTP 503": "https://www.drupal.org/files/issues/2021-06-07/2893407-47.patch",
         "Callers of LayoutEntityHelperTrait::getEntitySections() do not account for the view mode": "https://www.drupal.org/files/issues/2021-12-09/3008924-rerolled-24.patch",


### PR DESCRIPTION
Two patches needed reroll for core version 9.4.x:

- https://www.drupal.org/project/drupal/issues/1120020
- https://www.drupal.org/project/drupal/issues/2942975