### PR TITLE
Adding patch for Database update issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -119,6 +119,9 @@
       },
       "drupal/gin": {
         "Missing config schema": "https://www.drupal.org/files/issues/2022-05-09/missing_config_schema_3279472.patch"
+      },
+      "drupal/symfony_mailer": {
+        "Database update issue" : "https://www.drupal.org/files/issues/2023-05-02/symfony_mailer-3355235-db_update_error_plugin_does_not_exist-9.patch"
       }
     }
   }


### PR DESCRIPTION
When trying to run db update, i get the following error, needs to research https://www.drupal.org/node/3355235

` // Do you wish to run the specified pending updates?: yes.                     
 [notice] Database updates start.
> >  [notice] Update started: symfony_mailer_update_10007
> >  [error]  The "mailer_html_to_text" plugin does not exist. Valid plugin IDs for Drupal\symfony_mailer\Processor\EmailAdjusterManager are: email_theme, email_to, email_body, email_plain, email_subject, mailer_url_to_absolute, mailer_inline_css, email_from, mailer_wrap_and_convert, email_skip_sending, email_priority, email_cc, email_reply_to, email_transport, mailer_default_headers, mailer_hooks, email_bcc 
> >  [error]  Update failed: symfony_mailer_update_10007 
> >  [notice] Update started: views_bulk_operations_update_8035
> >  [notice] No conversions were required by Views Bulk Operations.
> >  [notice] Update completed: views_bulk_operations_update_8035
>  [error]  Update aborted by: symfony_mailer_update_10007 
>  [error]  Finished performing updates. 
In SiteProcess.php line 214:`

Found the following fix which is a workaround