### PR TITLE
Require drupal/core >= 10.1.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "drupal/block_content_permissions": "^1.11",
     "drupal/coffee": "^1.3",
     "drupal/config_override_warn": "^1.4",
-    "drupal/core-recommended": "^10.0.9",
+    "drupal/core-recommended": "^10.1.4",
     "drupal/custom_pub": "^1.0",
     "drupal/file_entity": "dev-2.x",
     "drupal/focal_point": "^2.0",
@@ -92,7 +92,6 @@
         "Claro + layout builder messages display additional icon in top left corner": "https://www.drupal.org/files/issues/2022-12-15/3143237-74.patch",
         "Expose Layout Builder data to REST and JSON:API": "https://www.drupal.org/files/issues/2023-02-08/2942975-230.patch",
         "Taxonomy pages crash with layout_builder enabled": "https://www.drupal.org/files/issues/2018-09-19/2959132-taxo-17-PASS.patch",
-        "Allow field blocks to display the configuration label when set in Layout Builder": "https://www.drupal.org/files/issues/2021-08-17/3039185-46.patch",
         "Add multilingual support for caching basefield definitions": "https://www.drupal.org/files/issues/2022-02-27/3114824-9.patch"
       },
       "drupal/block_content_permissions": {


### PR DESCRIPTION
- the last security release and new release for 10.1 compatibility
- patch drupal.org/i/3039185 commited to 10.1

Blocker for #46